### PR TITLE
Update opencv 0.52.0, add clang-runtime support, bump semver for potentially breaking update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cv-convert"
 description = "Type conversions among famous Rust computer vision libraries"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["jerry73204 <jerry73204@gmail.com>"]
 edition = "2018"
 documentation = "https://docs.rs/cv-convert/"
@@ -16,7 +16,7 @@ license = "MIT"
 anyhow = "1.0.40"
 image = { version = "0.23.14", optional = true }
 nalgebra = { version = "0.25.3", optional = true }
-opencv = { version = "0.51.0", default-features = false, optional = true }
+opencv = { version = "0.52.0", default-features = false, optional = true }
 ndarray = { version = "0.15.1", optional = true }
 tch = { version = "0.4.0", optional = true }
 
@@ -26,13 +26,13 @@ itertools = "0.10.0"
 rand = "0.8.3"
 
 [features]
-default = ["image", "opencv-4", "opencv-buildtime-bindgen", "tch", "nalgebra", "ndarray"]
-docs-only = ["opencv-4", "opencv-contrib", "opencv/docs-only", "tch", "tch/doc-only", "image", "nalgebra", "ndarray"]
+default = ["image", "opencv-4", "opencv-buildtime-bindgen", "opencv-clang-runtime", "tch", "nalgebra", "ndarray"]
+docs-only = ["opencv-4", "opencv/docs-only", "tch", "tch/doc-only", "image", "nalgebra", "ndarray"]
 opencv-4 = ["opencv", "opencv/opencv-4"]
 opencv-34 = ["opencv", "opencv/opencv-34"]
 opencv-32 = ["opencv", "opencv/opencv-32"]
-opencv-contrib = ["opencv", "opencv/contrib"]
 opencv-buildtime-bindgen = ["opencv", "opencv/buildtime-bindgen"]
+opencv-clang-runtime = ["opencv", "opencv/clang-runtime"]
 
 [package.metadata.docs.rs]
 no-default-features = true

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ opencv crate features
 - `opencv-34`: Enable `opencv-34` in opencv crate.
 - `opencv-32`: Enable `opencv-32` in opencv crate.
 - `opencv-buildtime-bindgen`: Enable `buildtime-bindgen` in opencv crate.
+- `opencv-clang-runtime`: Enable `clang-runtime` in opencv crate. Useful if you get `libclang shared library is not loaded on this thread!` panic.
+- `opencv-contrib`: `opencv-contrib` has been dropped by the main `opencv` crate in favour of runtime module set detection. If you need the older version, 0.5.0 was the version that last supported `opencv-0.51.0`. 
 
 image crate feature
 


### PR DESCRIPTION
This PR updates the crate to opencv 0.52, adds the clang-runtime feature to opencv, with a semver bump since opencv 0.52 no longer supports the contrib feature. 

I have verified that this PR passes all tests. 