### PR TITLE
Update nalgebra and opencv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cv-convert"
 description = "Type conversions among famous Rust computer vision libraries"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["jerry73204 <jerry73204@gmail.com>"]
 edition = "2018"
 documentation = "https://docs.rs/cv-convert/"
@@ -15,8 +15,8 @@ license = "MIT"
 [dependencies]
 anyhow = "1.0.40"
 image = { version = "0.23.14", optional = true }
-nalgebra = { version = "0.25.4", optional = true }
-opencv = { version = "0.52.0", default-features = false, optional = true }
+nalgebra = { version = "0.26.1", optional = true }
+opencv = { version = "0.53.0", default-features = false, optional = true }
 ndarray = { version = "0.15.1", optional = true }
 tch = { version = "0.4.0", optional = true }
 
@@ -26,12 +26,8 @@ itertools = "0.10.0"
 rand = "0.8.3"
 
 [features]
-default = ["image", "opencv-4", "opencv-buildtime-bindgen", "opencv-clang-runtime", "tch", "nalgebra", "ndarray"]
-docs-only = ["opencv-4", "opencv/docs-only", "tch", "tch/doc-only", "image", "nalgebra", "ndarray"]
-opencv-4 = ["opencv", "opencv/opencv-4"]
-opencv-34 = ["opencv", "opencv/opencv-34"]
-opencv-32 = ["opencv", "opencv/opencv-32"]
-opencv-buildtime-bindgen = ["opencv", "opencv/buildtime-bindgen"]
+default = ["image", "opencv-clang-runtime", "tch", "nalgebra", "ndarray"]
+docs-only = ["opencv/docs-only", "tch", "tch/doc-only", "image", "nalgebra", "ndarray"]
 opencv-clang-runtime = ["opencv", "opencv/clang-runtime"]
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -13,27 +13,26 @@ Add cv-convert to `Cargo.toml` to import most conversions by default.
 
 ```toml
 [dependencies.cv-convert]
-version = "0.6"
+version = "0.7"
 ```
 
 You can manually choose supported libraries to avoid bloating.
 
 ```toml
-version = "0.6"
+version = "0.7"
 default-features = false
-features = ["opencv-4", "opencv-buildtime-bindgen", "nalgebra"]
+features = ["opencv", "nalgebra"]
 ```
 
+The minimum supported `rustc` is 1.51
+You may use older versions of the crate (>=0.6) in order to use `rustc` versions that do not support const-generics.
 ## Supported Cargo Features
 
 opencv crate features
 
-- `opencv-4`: Enable `opencv-4` in opencv crate.
-- `opencv-34`: Enable `opencv-34` in opencv crate.
-- `opencv-32`: Enable `opencv-32` in opencv crate.
-- `opencv-buildtime-bindgen`: Enable `buildtime-bindgen` in opencv crate.
 - `opencv-clang-runtime`: Enable `clang-runtime` in opencv crate. Useful if you get `libclang shared library is not loaded on this thread!` panic.
 - `opencv-contrib`: `opencv-contrib` has been dropped by the main `opencv` crate in favour of runtime module set detection. If you need the older version, 0.5.0 was the version that last supported `opencv-0.51.0`. 
+- `opencv-4`, `opencv-34`, `opencv-32`, `opencv-buildtime-bindgen`: These features have been dropped in opencv-0.53.0 in favour of runtime generation and detection. cv-convert-0.6 was the last version that supported `opencv-0.52.0`, which had these features.
 
 image crate feature
 
@@ -42,6 +41,7 @@ image crate feature
 nalgebra crate feature
 
 - `nalgebra`
+- With the arrival of `nalgebra` 0.26, const-generic are used in this crate and are incompatible with previous versions of `nalgebra`. If you are pulling in previous versions of `nalgebra`, please use 0.6 or older.
 
 tch crate feature
 

--- a/src/with_opencv_tch.rs
+++ b/src/with_opencv_tch.rs
@@ -427,23 +427,23 @@ mod tests {
     #[test]
     fn tensor_as_image_and_mat_conv() -> Result<()> {
         for _ in 0..ROUNDS {
-            let c = 3;
-            let h = 16;
-            let w = 8;
+            let channels = 3;
+            let height = 16;
+            let width = 8;
 
-            let before = tch::Tensor::randn(&[c, h, w], tch::kind::FLOAT_CPU);
+            let before = tch::Tensor::randn(&[channels, height, width], tch::kind::FLOAT_CPU);
             let mat: core::Mat =
                 TensorAsImage::new(&before, ShapeConvention::Chw)?.try_into_cv()?;
             let after = tch::Tensor::try_from_cv(&mat)?.f_permute(&[2, 0, 1])?; // hwc -> chw
 
             // compare Tensor and Mat values
-            for row in 0..h {
-                for col in 0..w {
+            for row in 0..height {
+                for col in 0..width {
                     let pixel: &core::Vec3f = mat.at_2d(row as i32, col as i32)?;
-                    let [r, g, b] = **pixel;
-                    ensure!(f32::from(before.i((0, row, col))) == r, "value mismatch");
-                    ensure!(f32::from(before.i((1, row, col))) == g, "value mismatch");
-                    ensure!(f32::from(before.i((2, row, col))) == b, "value mismatch");
+                    let [red, green, blue] = **pixel;
+                    ensure!(f32::from(before.i((0, row, col))) == red, "value mismatch");
+                    ensure!(f32::from(before.i((1, row, col))) == green, "value mismatch");
+                    ensure!(f32::from(before.i((2, row, col))) == blue, "value mismatch");
                 }
             }
 
@@ -466,18 +466,18 @@ mod tests {
     #[test]
     fn tensor_from_mat_conv() -> Result<()> {
         for _ in 0..ROUNDS {
-            let c = 3;
-            let h = 16;
-            let w = 8;
+            let channel = 3;
+            let height = 16;
+            let width = 8;
 
-            let before = tch::Tensor::randn(&[c, h, w], tch::kind::FLOAT_CPU);
+            let before = tch::Tensor::randn(&[channel, height, width], tch::kind::FLOAT_CPU);
             let mat: core::Mat =
                 TensorAsImage::new(&before, ShapeConvention::Chw)?.try_into_cv()?;
             let after = TensorFromMat::try_from_cv(mat)?; // in hwc
 
             // compare original and recovered Tensor values
             {
-                ensure!(&after.size() == &[h, w, c], "size mismatch",);
+                ensure!(after.size() == [height, width, channel], "size mismatch",);
                 ensure!(
                     &before.f_permute(&[1, 2, 0])? == after.tensor(),
                     "value mismatch"

--- a/src/with_tch_ndarray.rs
+++ b/src/with_tch_ndarray.rs
@@ -32,7 +32,7 @@ mod to_ndarray_shape {
 
         fn to_ndarray_shape(&self) -> Result<Self::Output, Self::Error> {
             ensure!(
-                self.len() == 0,
+                self.is_empty(),
                 "empty empty tensor dimension, but get {:?}",
                 self
             );


### PR DESCRIPTION
Another day, another breaking opencv update. Check: [Changelog](https://github.com/twistedfall/opencv-rust/blob/master/CHANGES.md)

Also added nalgebra 0.26 support and added const generics and switched out the `MatrixMN` for `OMatrix`.
Translation3<->cv::Mat also now requires const-generics

Minimum rustc version bump to 1.51 due to use of const-generics

Confirmed that library builds and passes all tests on my machine. 