### PR TITLE
Imageproc to opencv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ version = '0.23.14'
 package = 'image'
 optional = true
 
-
 [dependencies.nalgebra_0-31]
 version = '0.31.0'
 package = 'nalgebra'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,14 @@ features = ['docs-only']
 
 [dependencies]
 anyhow = '1.0.53'
+num-traits = '0.2.15'
 slice-of-array = '0.3.1'
 half = '1.8.2'
+
+[dependencies.imageproc_0-23]
+version = '0.23.0'
+package = 'imageproc'
+optional = true
 
 [dependencies.image_0-24]
 version = '0.24.2'
@@ -97,6 +103,7 @@ rand = '0.8.4'
 [features]
 full = [
     'image_0-24',
+    'imageproc_0-23',
     'opencv_0-65',
     'tch_0-7',
     'nalgebra_0-31',

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Type conversions among famous Rust computer vision libraries. It supports the following crates:
 
 - [image](https://crates.io/crates/image)
+- [imageproc](https://crates.io/crates/imageproc)
 - [nalgebra](https://crates.io/crates/nalgebra)
 - [opencv](https://crates.io/crates/opencv)
 - [tch](https://crates.io/crates/tch)
@@ -55,6 +56,10 @@ Enable the corresponding feature below if you get `libclang shared library is no
 ### image
 
 - `image_0-23`
+
+### imageproc
+
+- `imageproc_0-23`
 
 ### ndarray
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The minimum supported `rustc` is 1.51. You may use older versions of the crate (
 
 ### opencv
 
+- `opencv_0-65`
+- `opencv_0-64`
 - `opencv_0-63`
 
 Enable the corresponding feature below if you get `libclang shared library is not loaded on this thread!` panic.
@@ -68,7 +70,7 @@ Enable the corresponding feature below if you get `libclang shared library is no
 
 ### tch
 
-- `tch_0-6`
+- `tch_0-7`
 
 ## Usage
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,12 @@
 //! - [(&)ImageBuffer](image::ImageBuffer) ->? [Mat](opencv::core::Mat)
 //! - [(&)DynamicImage](image::DynamicImage) ->? [Mat](opencv::core::Mat)
 //!
+//! ## opencv -> imageproc
+//! - [(&)Point_<T>](opencv::core::Point_) -> [Point<T>](imageproc::point::Point)
+//!
+//! ## imageproc -> opencv
+//! - [(&)Point<T>](imageproc::point::Point) -> [Point_<T>](opencv::core::Point_)
+//!
 //! ## opencv -> nalgebra
 //!
 //! - [(&)Mat](opencv::core::Mat) ->? [OMatrix](nalgebra::OMatrix)
@@ -185,6 +191,10 @@ pub use image_0_24 as image;
 #[cfg(feature = "image_0-23")]
 pub use image_0_23 as image;
 
+// imageproc exports
+#[cfg(feature = "imageproc_0-23")]
+pub use imageproc_0_23 as imageproc;
+
 // nalgebra exports
 #[cfg(feature = "nalgebra_0-31")]
 pub use nalgebra_0_31 as nalgebra;
@@ -241,6 +251,13 @@ has_image! {
     has_opencv! {
         mod with_opencv_image;
         pub use with_opencv_image::*;
+    }
+}
+
+has_imageproc! {
+    has_opencv! {
+        mod with_opencv_imageproc;
+        pub use with_opencv_imageproc::*;
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -108,7 +108,6 @@ macro_rules! has_ndarray {
 pub(crate) use has_ndarray;
 
 // tch
-
 macro_rules! if_tch {
     ($($item:item)*) => {
         $(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -83,6 +83,31 @@ macro_rules! has_image {
 }
 pub(crate) use has_image;
 
+// imageproc
+macro_rules! if_imageproc {
+    ($($item:item)*) => {
+        $(
+            #[cfg(any(
+                feature = "imageproc_0-23",
+            ))]
+            $item
+        )*
+    };
+}
+pub(crate) use if_imageproc;
+
+macro_rules! has_imageproc {
+    ($($item:item)*) => {
+        crate::utils::if_imageproc! {
+            #[allow(unused_imports)]
+            use crate::imageproc as _;
+            $($item)*
+        }
+    }
+}
+pub(crate) use has_imageproc;
+
+
 // ndarray
 macro_rules! if_ndarray {
     ($($item:item)*) => {

--- a/src/with_opencv_imageproc.rs
+++ b/src/with_opencv_imageproc.rs
@@ -1,0 +1,101 @@
+use crate::imageproc;
+use crate::opencv::core as core_cv;
+use crate::FromCv;
+
+impl<T> FromCv<&imageproc::point::Point<T>> for core_cv::Point_<T>
+where
+    T: num_traits::Num + Copy,
+{
+    fn from_cv(from: &imageproc::point::Point<T>) -> Self {
+        core_cv::Point_::new(from.x, from.y)
+    }
+}
+
+impl<T> FromCv<imageproc::point::Point<T>> for core_cv::Point_<T>
+where
+    T: num_traits::Num + Copy,
+{
+    fn from_cv(from: imageproc::point::Point<T>) -> Self {
+        FromCv::from_cv(&from)
+    }
+}
+
+impl<T> FromCv<&core_cv::Point_<T>> for imageproc::point::Point<T>
+where
+    T: num_traits::Num + Copy,
+{
+    fn from_cv(from: &core_cv::Point_<T>) -> Self {
+        Self::new(from.x, from.y)
+    }
+}
+
+impl<T> FromCv<core_cv::Point_<T>> for imageproc::point::Point<T>
+where
+    T: num_traits::Num + Copy,
+{
+    fn from_cv(from: core_cv::Point_<T>) -> Self {
+        FromCv::from_cv(&from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use approx::abs_diff_eq;
+    use crate::imageproc;
+    use crate::opencv::core as core_cv;
+    use crate::{common::ensure, FromCv, IntoCv};
+    use rand::prelude::*;
+    use std::f64;
+
+    #[test]
+    fn convert_opencv_imageproc() -> Result<()> {
+        let mut rng = rand::thread_rng();
+
+        for _ in 0..5000 {
+            // FromCv
+            // opencv to imageproc
+            {
+                let cv_point = core_cv::Point2d::new(rng.gen(), rng.gen());
+                let imageproc_point = imageproc::point::Point::<f64>::from_cv(&cv_point);
+                ensure!(
+                    abs_diff_eq!(cv_point.x, imageproc_point.x) && abs_diff_eq!(cv_point.y, imageproc_point.y),
+                    "point conversion failed"
+                );
+            }
+
+            // imageproc to opencv
+            {
+                let imageproc_point = imageproc::point::Point::<f64>::new(rng.gen(), rng.gen());
+                let cv_point = core_cv::Point2d::from_cv(&imageproc_point);
+                ensure!(
+                    abs_diff_eq!(imageproc_point.x, cv_point.x) && abs_diff_eq!(imageproc_point.y, cv_point.y),
+                    "point conversion failed"
+                );
+            }
+
+            // IntoCv
+            // opencv to imageproc
+            {
+                let cv_point = core_cv::Point2d::new(rng.gen(), rng.gen());
+                let imageproc_point: imageproc::point::Point<f64> = cv_point.into_cv();
+                ensure!(
+                    abs_diff_eq!(cv_point.x, imageproc_point.x) && abs_diff_eq!(cv_point.y, imageproc_point.y),
+                    "point conversion failed"
+                );
+            }
+
+            // imageproc to opencv
+           {
+                let imageproc_point = imageproc::point::Point::<f64>::new(rng.gen(), rng.gen());
+                let cv_point: core_cv::Point2d = imageproc_point.into_cv();
+                ensure!(
+                    abs_diff_eq!(imageproc_point.x, cv_point.x) && abs_diff_eq!(imageproc_point.y, cv_point.y),
+                    "point conversion failed"
+                );
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR includes a conversion from imageproc::point::Point (https://crates.io/crates/imageproc) to opencv point. Given that there are several implementations purely in rust, this conversion would be a nice addition to the already existing conversions.